### PR TITLE
Add requirements to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ Pomodoro timer is a simple timer that helps you to stay focused on your tasks.
 
 </div>
 
+# Requirements
+
+- libasound2 development files
+    - `apt-get install libasound2-dev` on Debian derivatives
+    - `dnf install alsa-lib-devel` on Fedora
+
 # Installation
 
 ### Download binary


### PR DESCRIPTION
Great library! Love to have it running on my system.

I needed to install development files for Libasound2 before being able to install it using `cargo`. I tried it out in the official rust docker image - `libasound2-dev` was the only library I needed to install to make installation via cargo work (just `libasound2` was not enough).